### PR TITLE
@

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+A single-process MCP (Model Context Protocol) server that exposes Snowflake to MCP clients (Claude Desktop, VS Code) over stdio. Designed to run behind a corporate proxy. Python ≥3.10, packaged with `uv`/hatchling, published to PyPI as `simple-snowflake-mcp`.
+
+## Commands
+
+```bash
+uv sync --all-extras        # Install all deps incl. dev (creates venv)
+uv run simple-snowflake-mcp # Run the server (stdio)
+uv run pytest               # Run tests
+uv run pytest tests/test_snowflake.py::test_list_snowflake_warehouses  # Single test
+uv run ruff check .         # Lint
+uv run ruff format .        # Format
+uv run mypy src             # Type check
+uv build                    # Build distribution
+```
+
+Tests are async (`asyncio_mode = "auto"`) and **mock `snowflake.connector.connect`** — they run in CI with no credentials and never touch a live account. `tests/test_security.py` holds the security regression tests (one per audit finding); `tests/test_snowflake.py` holds tool-dispatch smoke tests.
+
+CI: `.github/workflows/ci.yml` runs ruff + pytest on push/PR; `.github/workflows/workflow.yml` builds and publishes to PyPI on `v*` tags.
+
+## Architecture
+
+Essentially everything lives in `src/simple_snowflake_mcp/server.py` (~900 lines). `__init__.py` just calls `asyncio.run(server.main())`.
+
+The server is built on the `mcp` library's `Server` object (module-global `server`). MCP capabilities are registered via decorators, all defined in `server.py`:
+- `@server.list_tools()` / `@server.call_tool()` — the tools
+- `@server.list_resources()` / `@server.read_resource()` / `@server.subscribe_resource()` / `@server.unsubscribe_resource()` — Snowflake resources + subscription notifications
+- `@server.list_prompts()` / `@server.get_prompt()` — prompts
+
+`handle_call_tool` is a single large `if/elif` dispatch on tool name. **All Snowflake access funnels through one chokepoint, `_safe_snowflake_execute(query, description, *, is_user_sql=False, row_limit=None)`** — this is deliberate and security-critical. It applies the read-only guard, executes via a reused connection (`_get_connection`/`_reset_connection`) under a `threading.Lock`, bounds rows via `fetchmany`, and returns `{"success", "data", "error"}` with client-safe (generic) error text while logging full detail. The two user SQL tools both route through `_run_user_query`, which calls the chokepoint with `is_user_sql=True`. Internal server queries (resources/prompts) call it with the default `is_user_sql=False`.
+
+### Security invariants (do not regress — see `security-audit-report.pdf` and `tests/test_security.py`)
+- **Read-only is server-governed only.** `READ_ONLY` derives from config + the `MCP_READ_ONLY` env var; there is **no** client `read_only` argument. Enforcement lives in `is_read_only_sql` (strips comments, rejects multi-statement and CTE-fronted DML) and is applied inside `_safe_snowflake_execute`, so no tool can skip it. Keyword filtering is defense-in-depth; the real boundary is a least-privilege Snowflake role (documented in README).
+- **Never string-concatenate user input into SQL.** `LIKE` values go through `validate_like_pattern` (allow-list regex); `limit` goes through `_coerce_limit` (bounded int, applied at the driver).
+- **Never return raw `str(e)` to the client.** Use the generic-message-plus-`ref` pattern; log detail via `_log_exception`.
+- **Don't log SQL/args at INFO** — only a hash/length; full text is DEBUG-only.
+
+### Configuration
+1. **`config.yaml`** — loaded by `load_config()` at import into global `CONFIG`, deep-merged onto `DEFAULT_CONFIG` and run through `_validate_config` (coerces security-sensitive types/bounds). The path comes from `_resolve_config_path`, which constrains `CONFIG_FILE` to `REPO_ROOT` (anti-traversal). Controls logging, query limits, statement timeout, connection reuse, rate limiting, notes bounds, and MCP capabilities.
+2. **`.env`** — Snowflake credentials read **lazily** at connect time by `get_snowflake_config()` (not at import), so container/test env injection works. `SNOWFLAKE_USER`/`PASSWORD`/`ACCOUNT` required; `WAREHOUSE`/`DATABASE`/`SCHEMA` optional. Missing required vars raise `SnowflakeConfigError`. Use `safe_config_echo()` (never the raw config) when returning connection info — it excludes the password.
+
+Precedence: env vars override `config.yaml` override `DEFAULT_CONFIG`.
+
+### Tool set
+The code implements 8 tools in `handle_list_tools`/`handle_call_tool`: `get-connection-info`, `add-note`, `delete-note`, `execute-snowflake-sql`, `list-snowflake-warehouses`, `list-databases`, `execute-query`, `export-schema`. (The README's tool list now matches.) When adding a tool, update both the schema in `handle_list_tools` and the dispatch branch — and if it runs user SQL, route it through `_run_user_query` so the guard applies.
+
+## Conventions
+
+- Comments and some log messages are in French; UI/tool text is mixed French/English. Match the surrounding language.
+- Ruff: line length 100, target py310, rules `E,F,I,N,W,UP`. CI (`.github/workflows/ci.yml`) runs `ruff check`, `ruff format --check`, and `pytest` on push/PR — keep all three green.
+- Errors are returned to the client as `TextContent` strings via the `_text(...)` helper, not raised — preserve this so the MCP client gets a readable message rather than a transport failure.
+- Tests mock `snowflake.connector.connect`; they never hit a live account. Patch `server.READ_ONLY`/`server._RATE_LIMIT_ENABLED` and reset `server._connection` in fixtures (see `tests/`).

--- a/Dockerfile.secure
+++ b/Dockerfile.secure
@@ -1,60 +1,41 @@
-# Multi-stage build for better security and smaller image size
-FROM python:3.11-slim-bookworm as builder
+# Hardened multi-stage build using uv (mirrors Dockerfile, with extra hardening).
+# Builds from pyproject.toml + uv.lock — the project does not use requirements.txt/setup.py.
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim AS builder
 
-# Set working directory
 WORKDIR /app
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y \
-    gcc \
-    g++ \
-    && rm -rf /var/lib/apt/lists/*
+# Install dependencies first (better layer caching), then the project itself.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
 
-# Copy dependency files
-COPY requirements.txt pyproject.toml uv.lock ./
-
-# Install uv for faster package management
-RUN pip install --no-cache-dir uv
-
-# Install dependencies using uv to a local directory
-RUN uv pip install --python /usr/local/bin/python --target /app/dependencies -r requirements.txt
+COPY src/ ./src/
+RUN uv sync --frozen --no-dev
 
 # Production stage
-FROM python:3.11-slim-bookworm as production
+FROM python:3.11-slim-bookworm AS production
 
-# Install security updates
+# Apply security updates
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
-# Set working directory
 WORKDIR /app
 
-# Copy dependencies from builder stage
-COPY --from=builder /app/dependencies /app/dependencies
+# Copy the resolved virtual environment and source from the builder.
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/src /app/src
 
-# Copy source code
-COPY src/ ./src/
-COPY setup.py ./
+# Create a non-root user with a fixed UID/GID and own the app directory.
+RUN groupadd -r -g 1001 mcp && \
+    useradd -r -g mcp -u 1001 -m -s /bin/bash mcp && \
+    mkdir -p /app/logs && \
+    chown -R mcp:mcp /app
 
-# Add dependencies to Python path
-ENV PYTHONPATH=/app/dependencies:/app/src
-
-# Create a non-root user with specific UID/GID
-RUN groupadd -r -g 1001 mcp && useradd -r -g mcp -u 1001 -m -s /bin/bash mcp
-
-# Create logs directory and set permissions
-RUN mkdir -p /app/logs && chown -R mcp:mcp /app
-
-# Switch to non-root user
 USER mcp
 
-# Set security-focused environment variables
+# Security-focused environment.
+ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONHASHSEED=random
 
-# Health check (uncomment if your MCP server supports health checks)
-# HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-#   CMD python -c "import sys; sys.exit(0)"
-
-# Default command
-CMD ["python", "-m", "simple_snowflake_mcp"]
+# Default command (entry point installed by the project).
+CMD ["simple-snowflake-mcp"]

--- a/README.md
+++ b/README.md
@@ -6,28 +6,55 @@ A production-ready MCP server that provides seamless Snowflake integration with 
 
 ### Tools
 
-The server exposes comprehensive MCP tools to interact with Snowflake:
+The server exposes the following MCP tools to interact with Snowflake:
 
-**Core Database Operations:**
-- **execute-snowflake-sql**: Executes a SQL query on Snowflake and returns the result (list of dictionaries)
-- **execute-query**: Executes a SQL query in read-only mode (SELECT, SHOW, DESCRIBE, EXPLAIN, WITH) or not (if `read_only` is false), result in markdown format
-- **query-view**: Queries a view with an optional row limit (markdown result)
+**Database Operations:**
+- **execute-snowflake-sql**: Executes a SQL query on Snowflake and returns the result. Supports `json` (default), `markdown`, and `csv` output via the `format` argument.
+- **execute-query**: Executes a SQL query with server-enforced read-only protection. In read-only mode (the default) only `SELECT`, `SHOW`, `DESCRIBE`, `EXPLAIN`, and `WITH` statements (without DML) are allowed. Read-only mode is governed **solely by server configuration** and cannot be relaxed by the caller. Supports a `limit` and `markdown` (default)/`json`/`csv` output via `format`.
 
 **Discovery and Metadata:**
-- **list-snowflake-warehouses**: Lists available Data Warehouses (DWH) on Snowflake
-- **list-databases**: Lists all accessible Snowflake databases
-- **list-schemas**: Lists all schemas in a specified database
-- **list-tables**: Lists all tables in a database and schema
-- **list-views**: Lists all views in a database and schema
-- **describe-table**: Gives details of a table (columns, types, constraints)
-- **describe-view**: Gives details of a view (columns, SQL)
+- **get-connection-info**: Returns current Snowflake connection information and server status.
+- **list-snowflake-warehouses**: Lists available Data Warehouses (DWH) on Snowflake. Pass `include_details: false` for names only.
+- **list-databases**: Lists all accessible Snowflake databases. Supports a `pattern` filter (wildcards) and `include_details`.
+- **export-schema**: Exports database schema information. Supports `json` (default), `yaml`, and `sql` via `format`, an optional `database` filter, and `include_data_samples`.
 
-**Advanced Operations:**
-- **get-table-sample**: Gets sample data from a table
-- **explain-query**: Explains the execution plan of a SQL query
-- **show-query-history**: Shows recent query history
-- **get-warehouse-status**: Gets current warehouse status and usage
-- **validate-sql**: Validates SQL syntax without execution
+**Notes (in-memory session state):**
+- **add-note**: Adds or updates a note (`name`, `content`) kept in server memory for the session.
+- **delete-note**: Deletes an existing note by `name`.
+
+## 🔒 Security Model
+
+This server executes client-supplied SQL against Snowflake using a single set of
+credentials. Treat the MCP client as untrusted (an LLM can be prompt-injected) and
+deploy accordingly.
+
+> **The real security boundary is a least-privilege Snowflake role, not the
+> server's keyword filter.** The built-in read-only check is *defense-in-depth
+> only*. Always connect with a role scoped to exactly what you need.
+
+**Required deployment posture:**
+
+1. **Use a least-privilege, read-only Snowflake role.** For read-only deployments,
+   grant only `USAGE`/`SELECT` (and the relevant `SHOW`/`DESCRIBE` visibility) — no
+   `INSERT`/`UPDATE`/`DELETE`/DDL/`GRANT`. If the role cannot write, no bypass of the
+   keyword filter can cause damage.
+2. **Keep `read_only: true`** (the default). Read-only mode is governed solely by
+   server configuration / the `MCP_READ_ONLY` environment variable. It is **not**
+   client-controllable — there is no `read_only` tool argument.
+3. **Set a statement timeout and rate limit** (see `config.yaml`) to bound runaway
+   or abusive queries and warehouse-credit consumption.
+
+**What the server enforces:**
+
+- Read-only mode applies to **every** SQL-executing tool through a single guard;
+  comments are stripped, multi-statement input and CTE-fronted DML (e.g.
+  `WITH ... DELETE`) are rejected.
+- `pattern` / `database` arguments are validated against a strict allow-list before
+  being placed into `LIKE` clauses; `limit` is coerced to a bounded integer and
+  applied at the driver, never concatenated into SQL.
+- Snowflake errors are **not** returned verbatim to the client; a generic message
+  with a reference id is returned and full detail is logged server-side.
+- Query text is not logged at `INFO` (only a length + hash); full SQL is `DEBUG`-only.
 
 ## 🆕 Configuration System (v0.2.0)
 
@@ -50,14 +77,29 @@ server:
   name: "simple_snowflake_mcp"
   version: "0.2.0"
   description: "Enhanced Snowflake MCP Server with full protocol compliance"
-  connection_timeout: 30
-  read_only: true  # Set to false to allow write operations
+  connection:
+    test_on_startup: true
+    timeout: 30
 
 # Snowflake Configuration
 snowflake:
+  # Read-only mode is read from here (and the MCP_READ_ONLY env var), NOT from
+  # the server block. Set to false to allow write operations.
   read_only: true
   default_query_limit: 1000
   max_query_limit: 50000
+  statement_timeout_seconds: 300
+  connection_reuse: true
+
+# Security controls
+security:
+  rate_limit:
+    enabled: true
+    max_calls: 60
+    window_seconds: 60
+  notes:
+    max_count: 100
+    max_content_length: 10000
 
 # MCP Protocol Settings
 mcp:
@@ -390,7 +432,7 @@ The result will be returned in the MCP response.
    - Ouvrir la palette de commandes (Ctrl+Shift+P), taper `MCP: Start Server` et sélectionner `simple-snowflake-mcp`.
 
 5. **Utilisation**
-   - Les outils MCP exposés vous permettent d'interroger Snowflake (list-databases, list-views, describe-view, query-view, execute-query, etc.).
+   - Les outils MCP exposés vous permettent d'interroger Snowflake (list-databases, list-snowflake-warehouses, execute-query, execute-snowflake-sql, export-schema, etc.).
    - Pour plus d'exemples, voir la documentation du protocole MCP : https://github.com/modelcontextprotocol/create-python-server
 
 ## Enhanced MCP Features (v0.2.0)
@@ -431,31 +473,22 @@ The server advertises these MCP capabilities:
 
 ## Supported MCP Functions
 
-The server exposes comprehensive MCP tools to interact with Snowflake:
+The server exposes the following MCP tools (see the [Tools](#tools) section above for full argument details):
 
-**Core Database Operations:**
-- **execute-snowflake-sql**: Executes a SQL query and returns structured results
-- **execute-query**: Advanced query execution with multiple output formats
-- **query-view**: Optimized view querying with result limiting
-- **validate-sql**: SQL syntax validation without execution
+**Database Operations:**
+- **execute-snowflake-sql**: Executes a SQL query and returns results as JSON, markdown, or CSV
+- **execute-query**: Query execution with read-only protection, row limit, and multiple output formats
 
 **Discovery and Metadata:**
+- **get-connection-info**: Current connection information and server status
 - **list-snowflake-warehouses**: Lists available Data Warehouses with status
-- **list-databases**: Lists all accessible databases with metadata  
-- **list-schemas**: Lists all schemas in a specified database
-- **list-tables**: Lists all tables with column information
-- **list-views**: Lists all views with definitions
-- **describe-table**: Detailed table schema and constraints
-- **describe-view**: View definition and column details
+- **list-databases**: Lists all accessible databases, with optional pattern filtering
+- **export-schema**: Exports database schema in JSON, YAML, or SQL format
 
-**Advanced Analytics:**
-- **get-table-sample**: Sample data extraction with configurable limits
-- **explain-query**: Query execution plan analysis
-- **show-query-history**: Recent query history with performance metrics
-- **get-warehouse-status**: Real-time warehouse status and usage
-- **get-account-usage**: Account-level usage statistics
+**Session Notes:**
+- **add-note** / **delete-note**: Manage in-memory notes for the session
 
-For detailed usage examples and parameter schemas, see the MCP protocol documentation.
+The server also implements MCP **resources** (Snowflake objects with subscription support) and **prompts**. For parameter schemas, inspect `handle_list_tools` in `src/simple_snowflake_mcp/server.py`.
 
 ## 🚀 Getting Started Examples
 
@@ -482,15 +515,26 @@ For detailed usage examples and parameter schemas, see the MCP protocol document
 # config_production.yaml
 logging:
   level: WARNING
-  file_logging: true
-  log_file: "/var/log/mcp_server.log"
+  file_logging:
+    enabled: true
+    filename: "/var/log/mcp_server.log"
 
-server:
-  read_only: false  # Allow write operations
-  
 snowflake:
+  # Keep true unless the connecting Snowflake role is itself read-only.
+  read_only: true
   default_query_limit: 5000
   max_query_limit: 100000
+  statement_timeout_seconds: 120
+  connection_reuse: true
+
+security:
+  rate_limit:
+    enabled: true
+    max_calls: 60
+    window_seconds: 60
+  notes:
+    max_count: 100
+    max_content_length: 10000
 
 mcp:
   experimental_features:

--- a/config.yaml
+++ b/config.yaml
@@ -30,12 +30,32 @@ server:
 
 # Snowflake Configuration (these can still be overridden by environment variables)
 snowflake:
-  # Read-only mode by default
+  # Read-only mode by default. This is the SERVER-SIDE policy and is never
+  # client-controllable. The MCP_READ_ONLY environment variable overrides it.
+  # NOTE: keyword filtering is defense-in-depth only — enforce read-only with a
+  # least-privilege, SELECT-only Snowflake role for a real security boundary.
   read_only: true
   # Default query limit for safety
   default_query_limit: 1000
   # Maximum query limit
   max_query_limit: 50000
+  # Server-side statement timeout, applied as a Snowflake session parameter.
+  statement_timeout_seconds: 300
+  # Reuse a single Snowflake connection across queries instead of opening a new
+  # authenticated connection per query (mitigates connection-exhaustion DoS).
+  connection_reuse: true
+
+# Security controls
+security:
+  # In-process sliding-window rate limit applied across all tool calls.
+  rate_limit:
+    enabled: true
+    max_calls: 60
+    window_seconds: 60
+  # Bounds on the in-memory notes store.
+  notes:
+    max_count: 100
+    max_content_length: 10000
 
 # MCP Protocol Settings
 mcp:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,8 +5,10 @@ version: '3.8'
 
 services:
   simple-snowflake-mcp:
-    # Use the more secure Dockerfile
-    dockerfile: Dockerfile.secure
+    # Use the more secure Dockerfile (dockerfile must be nested under build).
+    build:
+      context: .
+      dockerfile: Dockerfile.secure
     # Remove development volumes
     volumes:
       - ./logs:/app/logs:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,9 @@ services:
     env_file:
       - .env
     volumes:
-      - ./src:/app/src
+      # Source is mounted read-only: live code is visible but the container
+      # cannot tamper with it, and the dev profile must never run in production.
+      - ./src:/app/src:ro
       - ./logs:/app/logs
     profiles:
       - dev

--- a/src/simple_snowflake_mcp/__init__.py
+++ b/src/simple_snowflake_mcp/__init__.py
@@ -7,11 +7,13 @@ def main():
     """Main entry point for the package."""
     asyncio.run(server.main())
 
+
 # Optionally expose other important items at package level
-__all__ = ['main', 'server']
+__all__ = ["main", "server"]
 
 if __name__ == "__main__":
     import asyncio
 
     from .server import main
+
     asyncio.run(main())

--- a/src/simple_snowflake_mcp/server.py
+++ b/src/simple_snowflake_mcp/server.py
@@ -1,7 +1,12 @@
 import asyncio
+import hashlib
 import json
 import logging
 import os
+import re
+import threading
+import time
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -18,73 +23,166 @@ from pydantic import AnyUrl
 # Charger les variables d'environnement depuis le fichier .env
 load_dotenv()
 
-def load_config() -> dict[str, Any]:
+# Repository root, used to constrain where configuration files may be loaded from.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Built-in defaults. Extracted from load_config() so the baseline configuration
+# lives in one named place rather than buried in the loader (CQ-L4).
+DEFAULT_CONFIG: dict[str, Any] = {
+    "logging": {
+        "level": "INFO",
+        "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        "file_logging": {
+            "enabled": False,
+            "filename": "logs/server.log",
+            "max_bytes": 10485760,
+            "backup_count": 5,
+        },
+    },
+    "server": {
+        "name": "simple_snowflake_mcp",
+        "version": "0.2.0",
+        "description": "Enhanced Snowflake MCP Server with full protocol compliance",
+        "connection": {
+            "test_on_startup": True,
+            "timeout": 30,
+        },
+    },
+    "snowflake": {
+        "read_only": True,
+        "default_query_limit": 1000,
+        "max_query_limit": 50000,
+        # Server-side statement timeout, applied as a Snowflake session parameter.
+        "statement_timeout_seconds": 300,
+        # Reuse a single Snowflake connection across queries instead of opening a
+        # new authenticated connection per query (mitigates connection-exhaustion DoS).
+        "connection_reuse": True,
+    },
+    "security": {
+        # Simple in-process sliding-window rate limit across all tool calls.
+        "rate_limit": {
+            "enabled": True,
+            "max_calls": 60,
+            "window_seconds": 60,
+        },
+        # Bounds on the in-memory notes store.
+        "notes": {
+            "max_count": 100,
+            "max_content_length": 10000,
+        },
+    },
+    "mcp": {
+        "experimental_features": {
+            "resource_subscriptions": True,
+            "completion_support": False,
+        },
+        "notifications": {
+            "resources_changed": True,
+            "tools_changed": True,
+            "prompts_changed": True,
+        },
+    },
+}
+
+
+def _deep_merge(default: dict[str, Any], loaded: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``loaded`` into a copy of ``default``."""
+    for key, value in loaded.items():
+        if key in default and isinstance(default[key], dict) and isinstance(value, dict):
+            _deep_merge(default[key], value)
+        else:
+            default[key] = value
+    return default
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1", "yes", "on")
+    return default
+
+
+def _as_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, result))
+
+
+def _resolve_config_path() -> Path | None:
     """
-    Load configuration from config.yaml file.
-    Falls back to default values if file is not found or has issues.
+    Resolve the configuration file path from CONFIG_FILE, constrained to REPO_ROOT.
+
+    Prevents path traversal / absolute-path injection via CONFIG_FILE (SEC-M4):
+    a value that resolves outside the repository is rejected and the default
+    config.yaml is used instead.
     """
     config_file = os.getenv("CONFIG_FILE", "config.yaml")
-    config_path = Path(__file__).parent.parent.parent / config_file
-    default_config = {
-        "logging": {
-            "level": "INFO",
-            "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            "file_logging": {
-                "enabled": False,
-                "filename": "logs/server.log",
-                "max_bytes": 10485760,
-                "backup_count": 5
-            }
-        },
-        "server": {
-            "name": "simple_snowflake_mcp",
-            "version": "0.2.0",
-            "description": "Enhanced Snowflake MCP Server with full protocol compliance",
-            "connection": {
-                "test_on_startup": True,
-                "timeout": 30
-            }
-        },
-        "snowflake": {
-            "read_only": True,
-            "default_query_limit": 1000,
-            "max_query_limit": 50000
-        },
-        "mcp": {
-            "experimental_features": {
-                "resource_subscriptions": True,
-                "completion_support": False
-            },
-            "notifications": {
-                "resources_changed": True,
-                "tools_changed": True,
-                "prompts_changed": True
-            }
-        }
-    }
+    candidate = (REPO_ROOT / config_file).resolve()
+    if not candidate.is_relative_to(REPO_ROOT):
+        print(f"CONFIG_FILE '{config_file}' resolves outside the repository; ignoring it.")
+        candidate = (REPO_ROOT / "config.yaml").resolve()
+    return candidate
 
+
+def _validate_config(config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Coerce security-sensitive merged values to safe types/bounds (SEC-M4).
+
+    A malicious or mistaken config must not be able to silently disable a control
+    by supplying, e.g., read_only as the string "false" or an absurd query limit.
+    """
+    sf = config.setdefault("snowflake", {})
+    sf["read_only"] = _as_bool(sf.get("read_only", True), default=True)
+    sf["max_query_limit"] = _as_int(sf.get("max_query_limit", 50000), 50000, 1, 10_000_000)
+    sf["default_query_limit"] = _as_int(
+        sf.get("default_query_limit", 1000), 1000, 1, sf["max_query_limit"]
+    )
+    sf["statement_timeout_seconds"] = _as_int(
+        sf.get("statement_timeout_seconds", 300), 300, 1, 86_400
+    )
+    sf["connection_reuse"] = _as_bool(sf.get("connection_reuse", True), default=True)
+
+    sec = config.setdefault("security", {})
+    rl = sec.setdefault("rate_limit", {})
+    rl["enabled"] = _as_bool(rl.get("enabled", True), default=True)
+    rl["max_calls"] = _as_int(rl.get("max_calls", 60), 60, 1, 1_000_000)
+    rl["window_seconds"] = _as_int(rl.get("window_seconds", 60), 60, 1, 86_400)
+    nt = sec.setdefault("notes", {})
+    nt["max_count"] = _as_int(nt.get("max_count", 100), 100, 0, 1_000_000)
+    nt["max_content_length"] = _as_int(nt.get("max_content_length", 10000), 10000, 0, 10_000_000)
+    return config
+
+
+def load_config() -> dict[str, Any]:
+    """
+    Load configuration from a YAML file, deep-merged onto DEFAULT_CONFIG and
+    validated. Falls back to defaults if the file is missing or unreadable.
+    """
+    import copy
+
+    default_config = copy.deepcopy(DEFAULT_CONFIG)
+    config_path = _resolve_config_path()
     try:
-        if config_path.exists():
-            with open(config_path, encoding='utf-8') as f:
-                loaded_config = yaml.safe_load(f)
-                # Merge with default config to ensure all keys exist
-                def merge_configs(default, loaded):
-                    for key, value in loaded.items():
-                        if key in default and isinstance(default[key], dict) and isinstance(value, dict):
-                            merge_configs(default[key], value)
-                        else:
-                            default[key] = value
-                    return default
-                return merge_configs(default_config, loaded_config)
-        else:
-            print(f"Config file not found at {config_path}, using defaults")
-            return default_config
+        if config_path and config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                loaded_config = yaml.safe_load(f) or {}
+            if not isinstance(loaded_config, dict):
+                print(f"Config file {config_path} is not a mapping; using defaults")
+                return _validate_config(default_config)
+            return _validate_config(_deep_merge(default_config, loaded_config))
+        print(f"Config file not found at {config_path}, using defaults")
+        return _validate_config(default_config)
     except Exception as e:
         print(f"Error loading config file: {e}, using defaults")
-        return default_config
+        return _validate_config(default_config)
+
 
 # Load configuration
 CONFIG = load_config()
+
 
 def setup_logging():
     """Setup logging based on configuration."""
@@ -105,18 +203,20 @@ def setup_logging():
     if file_config.get("enabled", False):
         try:
             from logging.handlers import RotatingFileHandler
+
             log_file = Path(file_config.get("filename", "logs/server.log"))
             log_file.parent.mkdir(exist_ok=True)
 
             file_handler = RotatingFileHandler(
                 log_file,
                 maxBytes=file_config.get("max_bytes", 10485760),
-                backupCount=file_config.get("backup_count", 5)
+                backupCount=file_config.get("backup_count", 5),
             )
             file_handler.setFormatter(logging.Formatter(log_format))
             logging.getLogger().addHandler(file_handler)
         except Exception as e:
             print(f"Failed to setup file logging: {e}")
+
 
 # Setup logging
 setup_logging()
@@ -135,78 +235,368 @@ SERVER_INFO = {
     "version": CONFIG["server"]["version"],
     "description": CONFIG["server"]["description"],
     "author": "Yann Barraud",
-    "license": "MIT"
+    "license": "MIT",
 }
 
 server = Server("simple_snowflake_mcp")
 
-# Configuration Snowflake (à adapter avec vos identifiants)
-SNOWFLAKE_CONFIG = {
-    "user": os.getenv("SNOWFLAKE_USER"),
-    "password": os.getenv("SNOWFLAKE_PASSWORD"),
-    "account": os.getenv("SNOWFLAKE_ACCOUNT"),
-}
-
-# Ajout dynamique des paramètres optionnels si présents
-def _add_optional_snowflake_params(config):
-    for opt in [
-        ("warehouse", "SNOWFLAKE_WAREHOUSE"),
-        ("database", "SNOWFLAKE_DATABASE"),
-        ("schema", "SNOWFLAKE_SCHEMA")
-    ]:
-        val = os.getenv(opt[1])
-        if val:
-            config[opt[0]] = val
-_add_optional_snowflake_params(SNOWFLAKE_CONFIG)
-
-# Ajout d'une variable globale pour le mode read-only par défaut (TRUE par défaut)
-# Environment variable overrides config file
-MCP_READ_ONLY = os.getenv("MCP_READ_ONLY", str(CONFIG["snowflake"]["read_only"])).lower() == "true"
+# Read-only mode is derived solely from server configuration; the environment
+# variable overrides the config file. It is NEVER client-controllable (SEC-C2/M1).
+READ_ONLY = _as_bool(
+    os.getenv("MCP_READ_ONLY", str(CONFIG["snowflake"]["read_only"])), default=True
+)
 DEFAULT_QUERY_LIMIT = CONFIG["snowflake"]["default_query_limit"]
 MAX_QUERY_LIMIT = CONFIG["snowflake"]["max_query_limit"]
+STATEMENT_TIMEOUT_SECONDS = CONFIG["snowflake"]["statement_timeout_seconds"]
+CONNECTION_REUSE = CONFIG["snowflake"]["connection_reuse"]
+CONNECTION_TIMEOUT = CONFIG["server"]["connection"].get("timeout", 30)
 
-def _safe_snowflake_execute(query: str, description: str = "Query") -> dict[str, Any]:
+# Required Snowflake credential keys.
+_REQUIRED_SNOWFLAKE_KEYS = ("user", "password", "account")
+# Connection config keys that are safe to echo back to a client (never the password).
+_SAFE_CONFIG_KEYS = ("user", "account", "warehouse", "database", "schema")
+
+
+class SnowflakeConfigError(Exception):
+    """Raised when required Snowflake connection settings are missing."""
+
+
+def get_snowflake_config() -> dict[str, Any]:
     """
-    Safely execute a Snowflake query with proper error handling and logging.
+    Build Snowflake connection kwargs from the environment at call time (CQ-C3).
+
+    Reading env lazily (rather than at import) means credentials injected by a
+    container entrypoint or a test are honored. Raises SnowflakeConfigError if a
+    required setting is missing.
     """
+    config: dict[str, Any] = {
+        "user": os.getenv("SNOWFLAKE_USER"),
+        "password": os.getenv("SNOWFLAKE_PASSWORD"),
+        "account": os.getenv("SNOWFLAKE_ACCOUNT"),
+    }
+    missing = [k for k in _REQUIRED_SNOWFLAKE_KEYS if not config[k]]
+    if missing:
+        raise SnowflakeConfigError(
+            "Missing required Snowflake settings: "
+            + ", ".join(f"SNOWFLAKE_{k.upper()}" for k in missing)
+        )
+
+    for key, env_name in (
+        ("warehouse", "SNOWFLAKE_WAREHOUSE"),
+        ("database", "SNOWFLAKE_DATABASE"),
+        ("schema", "SNOWFLAKE_SCHEMA"),
+    ):
+        value = os.getenv(env_name)
+        if value:
+            config[key] = value
+
+    # Bound how long connection and queries may run (SEC-M3, CQ-H2).
+    config["login_timeout"] = CONNECTION_TIMEOUT
+    config["network_timeout"] = CONNECTION_TIMEOUT
+    config["session_parameters"] = {
+        "STATEMENT_TIMEOUT_IN_SECONDS": STATEMENT_TIMEOUT_SECONDS,
+    }
+    return config
+
+
+def safe_config_echo() -> dict[str, Any]:
+    """Return non-secret connection info suitable for returning to a client."""
     try:
-        logger.info(f"Executing {description}: {query[:100]}...")
-        ctx = snowflake.connector.connect(**SNOWFLAKE_CONFIG)
-        cur = ctx.cursor()
-        cur.execute(query)
+        cfg = get_snowflake_config()
+    except SnowflakeConfigError as e:
+        return {"error": str(e)}
+    return {k: cfg[k] for k in _SAFE_CONFIG_KEYS if cfg.get(k)}
 
-        # Handle different query types
-        if cur.description:
-            rows = cur.fetchall()
-            columns = [desc[0] for desc in cur.description]
-            result = [dict(zip(columns, row)) for row in rows]
-        else:
-            result = {"status": "success", "rowcount": cur.rowcount}
 
-        cur.close()
-        ctx.close()
-        logger.info(f"{description} completed successfully")
+# ---------------------------------------------------------------------------
+# Read-only enforcement (SEC-C1, SEC-C2, CQ-H1)
+# ---------------------------------------------------------------------------
+# Keyword filtering is DEFENSE-IN-DEPTH ONLY. The real security boundary must be
+# a least-privilege, SELECT-only Snowflake role (see README). This guard exists
+# so a misconfigured deployment fails closed rather than open.
+
+_READ_ONLY_PREFIXES = frozenset({"SELECT", "SHOW", "DESCRIBE", "DESC", "EXPLAIN", "WITH"})
+# Tokens that perform writes / DDL / side effects. Used to reject CTE-fronted DML
+# (e.g. "WITH x AS (...) DELETE ...") and anything similar.
+_WRITE_TOKENS = frozenset(
+    {
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "MERGE",
+        "UPSERT",
+        "CREATE",
+        "DROP",
+        "ALTER",
+        "TRUNCATE",
+        "GRANT",
+        "REVOKE",
+        "CALL",
+        "COPY",
+        "PUT",
+        "GET",
+        "REMOVE",
+        "UNLOAD",
+        "USE",
+        "SET",
+        "UNSET",
+        "COMMENT",
+        "RENAME",
+        "REPLACE",
+        "EXECUTE",
+    }
+)
+
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+_WORD_RE = re.compile(r"[A-Za-z_]+")
+# Spans whose contents must not be interpreted as SQL keywords/separators:
+# dollar-quoted bodies, single-quoted string literals, and double-quoted
+# identifiers (each tolerating doubled-quote escapes).
+_DOLLAR_QUOTE_RE = re.compile(r"\$\$.*?\$\$", re.DOTALL)
+_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
+_QUOTED_IDENT_RE = re.compile(r'"(?:[^"]|"")*"')
+# A write/DDL token used as a *statement* keyword (followed by whitespace or
+# end-of-input), not as a function call such as REPLACE(...) or GET(...).
+_WRITE_TOKEN_RE = re.compile(
+    r"\b(?:" + "|".join(sorted(_WRITE_TOKENS)) + r")\b(?!\s*\()",
+    re.IGNORECASE,
+)
+
+
+def _strip_sql_noise(sql: str) -> str:
+    """
+    Remove comments and quoted spans so keyword/separator scanning operates only
+    on SQL structure, not on data. Prevents semicolons or keywords inside string
+    literals / identifiers from being mistaken for statement boundaries or DML.
+    """
+    sql = _BLOCK_COMMENT_RE.sub(" ", sql)
+    sql = _LINE_COMMENT_RE.sub(" ", sql)
+    sql = _DOLLAR_QUOTE_RE.sub(" ", sql)
+    sql = _STRING_LITERAL_RE.sub(" ", sql)
+    sql = _QUOTED_IDENT_RE.sub(" ", sql)
+    return sql.strip()
+
+
+def is_read_only_sql(sql: str) -> bool:
+    """
+    Conservative check that ``sql`` is a single read-only statement.
+
+    Strips comments and quoted spans, rejects multiple statements, requires an
+    allow-listed leading keyword, and (for WITH) rejects CTE-fronted DML. Quoted
+    data is removed first so semicolons or keywords inside literals do not cause
+    false rejections, and write tokens used as functions (e.g. REPLACE(), GET())
+    are distinguished from statement keywords (e.g. DELETE, INSERT).
+    """
+    cleaned = _strip_sql_noise(sql)
+    if not cleaned:
+        return False
+
+    # Reject multiple statements (ignore a single trailing semicolon).
+    statements = [s for s in cleaned.split(";") if s.strip()]
+    if len(statements) != 1:
+        return False
+    cleaned = statements[0].strip()
+
+    first_match = _WORD_RE.match(cleaned)
+    if not first_match:
+        return False
+    first_word = first_match.group(0).upper()
+    if first_word not in _READ_ONLY_PREFIXES:
+        return False
+
+    # A CTE may legally front DML in Snowflake; reject if a write statement
+    # keyword appears anywhere (a same-named function call is allowed).
+    if first_word == "WITH" and _WRITE_TOKEN_RE.search(cleaned):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Identifier validation (SEC-H1, CQ-C2)
+# ---------------------------------------------------------------------------
+# Allow the characters valid in Snowflake unquoted identifiers (letters, digits,
+# underscore, dollar) plus the LIKE wildcards % and _. Quotes, whitespace, and
+# statement separators remain rejected, so the value is injection-safe.
+_IDENTIFIER_PATTERN_RE = re.compile(r"^[A-Za-z0-9_$%]+$")
+# Word-boundary match for a LIMIT clause (not a substring of an identifier).
+_LIMIT_KEYWORD_RE = re.compile(r"\bLIMIT\b", re.IGNORECASE)
+
+
+def validate_like_pattern(value: str, field: str) -> str:
+    """
+    Validate a value destined for a ``LIKE '...'`` clause. SHOW ... LIKE does not
+    accept bind parameters, so we restrict the value to a safe character class
+    (letters, digits, underscore, dollar, and the % wildcard) to prevent injection.
+    """
+    if not isinstance(value, str) or not _IDENTIFIER_PATTERN_RE.match(value):
+        raise ValueError(f"Invalid {field}: only letters, digits, '_', '$' and '%' are permitted")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Connection management (CQ-C1, SEC-M2)
+# ---------------------------------------------------------------------------
+_connection = None
+_connection_lock = threading.Lock()
+_error_counter = 0
+
+
+def _get_connection():
+    """Return a (possibly cached) live Snowflake connection."""
+    global _connection
+    if _connection is None:
+        _connection = snowflake.connector.connect(**get_snowflake_config())
+    return _connection
+
+
+def _reset_connection() -> None:
+    """Close and discard the cached connection so the next call reconnects."""
+    global _connection
+    if _connection is not None:
+        try:
+            _connection.close()
+        except Exception:
+            pass
+        _connection = None
+
+
+def _sql_hash(query: str) -> str:
+    return hashlib.sha256(query.encode("utf-8", "replace")).hexdigest()[:12]
+
+
+def _log_exception(description: str, exc: Exception) -> str:
+    """Log full exception detail server-side with a reference id; return the id."""
+    global _error_counter
+    _error_counter += 1
+    ref = f"E{_error_counter:06d}"
+    logger.error("%s failed [ref %s]: %s", description, ref, exc)
+    return ref
+
+
+def _safe_snowflake_execute(
+    query: str,
+    description: str = "Query",
+    *,
+    is_user_sql: bool = False,
+    row_limit: int | None = None,
+) -> dict[str, Any]:
+    """
+    Execute a Snowflake query with read-only enforcement, resource-safe cleanup,
+    and client-safe error handling.
+
+    This is the single chokepoint for SQL execution. When ``is_user_sql`` is True
+    and the server is in read-only mode, the read-only guard is applied here so no
+    caller can bypass it (SEC-C1/SEC-C2). ``row_limit`` bounds rows at the driver
+    via fetchmany rather than editing SQL text (SEC-H2, CQ-M2).
+    """
+    if is_user_sql and READ_ONLY and not is_read_only_sql(query):
+        logger.warning(
+            "Rejected non-read-only query in read-only mode (%d chars, hash=%s)",
+            len(query),
+            _sql_hash(query),
+        )
+        return {
+            "success": False,
+            "error": (
+                "Only read-only queries (SELECT/SHOW/DESCRIBE/EXPLAIN/WITH without "
+                "DML) are permitted while the server is in read-only mode."
+            ),
+            "data": None,
+        }
+
+    # Do not log raw SQL (may contain PII/secrets) at INFO; emit a hash instead
+    # and reserve the full text for DEBUG (SEC-M2, CQ-M4).
+    logger.info("Executing %s (%d chars, hash=%s)", description, len(query), _sql_hash(query))
+    logger.debug("SQL for %s: %s", description, query)
+
+    try:
+        with _connection_lock:
+            try:
+                conn = _get_connection()
+                with conn.cursor() as cur:
+                    cur.execute(query)
+                    if cur.description:
+                        columns = [desc[0] for desc in cur.description]
+                        rows = cur.fetchmany(row_limit) if row_limit else cur.fetchall()
+                        result: Any = [dict(zip(columns, row)) for row in rows]
+                    else:
+                        result = {"status": "success", "rowcount": cur.rowcount}
+            except Exception:
+                # Drop the cached connection so a broken one is not reused.
+                _reset_connection()
+                raise
+            finally:
+                if not CONNECTION_REUSE:
+                    _reset_connection()
+
+        logger.info("%s completed successfully", description)
         return {"success": True, "data": result}
 
-    except Exception as e:
-        logger.error(f"{description} failed: {str(e)}")
+    except SnowflakeConfigError as e:
+        # Safe to surface: contains only which env vars are missing, no secrets.
+        logger.error("%s failed: %s", description, e)
         return {"success": False, "error": str(e), "data": None}
+    except Exception as e:
+        ref = _log_exception(description, e)
+        return {
+            "success": False,
+            "error": f"An internal error occurred while executing the query (ref {ref}).",
+            "data": None,
+        }
+
 
 def _format_markdown_table(data: list[dict[str, Any]]) -> str:
-    """Format query results as a markdown table."""
+    """Format query results as a markdown table, escaping cell contents."""
     if not data:
         return "No results found."
 
+    def _cell(value: Any) -> str:
+        if value is None:
+            return ""
+        # Escape pipes and collapse newlines so they don't break the table (CQ-L2).
+        text = str(value).replace("\\", "\\\\").replace("|", "\\|")
+        text = text.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+        if len(text) > 500:
+            text = text[:497] + "..."
+        return text
+
     columns = list(data[0].keys())
-    header = "| " + " | ".join(columns) + " |"
+    header = "| " + " | ".join(_cell(c) for c in columns) + " |"
     separator = "|" + "---|" * len(columns)
-
-    rows = []
-    for row in data:
-        row_str = "| " + " | ".join(str(row.get(col, "")) for col in columns) + " |"
-        rows.append(row_str)
-
+    rows = ["| " + " | ".join(_cell(row.get(col)) for col in columns) + " |" for row in data]
     return header + "\n" + separator + "\n" + "\n".join(rows)
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting (SEC-M3)
+# ---------------------------------------------------------------------------
+class _RateLimiter:
+    """Simple in-process sliding-window limiter over all tool invocations."""
+
+    def __init__(self, max_calls: int, window_seconds: int) -> None:
+        self.max_calls = max_calls
+        self.window = window_seconds
+        self._calls: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def allow(self) -> bool:
+        now = time.monotonic()
+        with self._lock:
+            while self._calls and now - self._calls[0] > self.window:
+                self._calls.popleft()
+            if len(self._calls) >= self.max_calls:
+                return False
+            self._calls.append(now)
+            return True
+
+
+_rate_limit_cfg = CONFIG["security"]["rate_limit"]
+_rate_limiter = _RateLimiter(_rate_limit_cfg["max_calls"], _rate_limit_cfg["window_seconds"])
+_RATE_LIMIT_ENABLED = _rate_limit_cfg["enabled"]
+_NOTES_MAX_COUNT = CONFIG["security"]["notes"]["max_count"]
+_NOTES_MAX_LENGTH = CONFIG["security"]["notes"]["max_content_length"]
+
 
 @server.list_resources()
 async def handle_list_resources() -> list[types.Resource]:
@@ -250,6 +640,7 @@ async def handle_list_resources() -> list[types.Resource]:
     logger.info(f"Listed {len(resources)} resources")
     return resources
 
+
 @server.read_resource()
 async def handle_read_resource(uri: AnyUrl) -> str:
     """
@@ -271,36 +662,42 @@ async def handle_read_resource(uri: AnyUrl) -> str:
             # Return comprehensive schema metadata
             result = _safe_snowflake_execute("SHOW DATABASES", "Schema metadata query")
             if result["success"]:
-                return json.dumps({
-                    "timestamp": datetime.now().isoformat(),
-                    "server_info": SERVER_INFO,
-                    "databases": result["data"],
-                    "connection_config": {k: v for k, v in SNOWFLAKE_CONFIG.items() if k != "password"}
-                }, indent=2)
+                return json.dumps(
+                    {
+                        "timestamp": datetime.now().isoformat(),
+                        "server_info": SERVER_INFO,
+                        "databases": result["data"],
+                        "connection_config": safe_config_echo(),
+                    },
+                    indent=2,
+                )
             else:
                 return json.dumps({"error": result["error"]}, indent=2)
 
         elif str(uri) == "snowflake://status/connection":
             # Return connection status
-            result = _safe_snowflake_execute("SELECT CURRENT_VERSION(), CURRENT_TIMESTAMP()", "Connection status")
+            result = _safe_snowflake_execute(
+                "SELECT CURRENT_VERSION(), CURRENT_TIMESTAMP()", "Connection status"
+            )
             if result["success"]:
                 status_data = {
                     "status": "connected",
                     "timestamp": datetime.now().isoformat(),
                     "snowflake_info": result["data"][0] if result["data"] else {},
                     "server_config": SERVER_INFO,
-                    "read_only_mode": MCP_READ_ONLY
+                    "read_only_mode": READ_ONLY,
                 }
             else:
                 status_data = {
                     "status": "error",
                     "timestamp": datetime.now().isoformat(),
                     "error": result["error"],
-                    "read_only_mode": MCP_READ_ONLY
+                    "read_only_mode": READ_ONLY,
                 }
             return json.dumps(status_data, indent=2)
 
     raise ValueError(f"Unsupported URI scheme or path: {uri}")
+
 
 @server.subscribe_resource()
 async def handle_subscribe_resource(uri: AnyUrl) -> None:
@@ -317,6 +714,7 @@ async def handle_subscribe_resource(uri: AnyUrl) -> None:
     # Add client to subscription (in a real implementation, you'd track client IDs)
     resource_subscriptions[uri_str].add("default_client")
 
+
 @server.unsubscribe_resource()
 async def handle_unsubscribe_resource(uri: AnyUrl) -> None:
     """
@@ -329,6 +727,7 @@ async def handle_unsubscribe_resource(uri: AnyUrl) -> None:
         resource_subscriptions[uri_str].discard("default_client")
         if not resource_subscriptions[uri_str]:
             del resource_subscriptions[uri_str]
+
 
 @server.list_prompts()
 async def handle_list_prompts() -> list[types.Prompt]:
@@ -350,7 +749,7 @@ async def handle_list_prompts() -> list[types.Prompt]:
                     name="format",
                     description="Output format (text/markdown/json)",
                     required=False,
-                )
+                ),
             ],
         ),
         types.Prompt(
@@ -366,7 +765,7 @@ async def handle_list_prompts() -> list[types.Prompt]:
                     name="focus",
                     description="Analysis focus (tables/views/functions/all)",
                     required=False,
-                )
+                ),
             ],
         ),
         types.Prompt(
@@ -382,7 +781,7 @@ async def handle_list_prompts() -> list[types.Prompt]:
                     name="complexity",
                     description="Query complexity level (simple/intermediate/advanced)",
                     required=False,
-                )
+                ),
             ],
         ),
         types.Prompt(
@@ -395,13 +794,12 @@ async def handle_list_prompts() -> list[types.Prompt]:
                     required=False,
                 )
             ],
-        )
+        ),
     ]
 
+
 @server.get_prompt()
-async def handle_get_prompt(
-    name: str, arguments: dict[str, str] | None
-) -> types.GetPromptResult:
+async def handle_get_prompt(name: str, arguments: dict[str, str] | None) -> types.GetPromptResult:
     """
     Generate a prompt by combining arguments with server state.
     Supports multiple prompt types with dynamic content generation.
@@ -445,15 +843,15 @@ async def handle_get_prompt(
         schema_info = result["data"] if result["success"] else [{"error": result["error"]}]
 
         prompt_text = f"""Analyze the following Snowflake database schema information:
-        
+
 Target: {database}
 Focus: {focus}
-        
+
 Schema Information:
 {json.dumps(schema_info, indent=2)}
 
 Please provide insights about:
-- Database structure and organization  
+- Database structure and organization
 - Table/view relationships (if focus includes tables/views)
 - Data patterns and potential optimizations
 - Recommended queries or analysis approaches
@@ -509,17 +907,21 @@ Ensure queries are compatible with Snowflake SQL dialect.
 
         # Get connection status
         status_result = _safe_snowflake_execute("SELECT CURRENT_VERSION()", "Connection test")
-        connection_status = "Connected successfully" if status_result["success"] else f"Connection failed: {status_result['error']}"
+        connection_status = (
+            "Connected successfully"
+            if status_result["success"]
+            else f"Connection failed: {status_result['error']}"
+        )
 
         prompt_text = f"""Help troubleshoot Snowflake connection issues:
 
 Error/Symptoms: {error_msg}
 Current Connection Status: {connection_status}
 Server Configuration: {SERVER_INFO}
-Read-Only Mode: {MCP_READ_ONLY}
+Read-Only Mode: {READ_ONLY}
 
 Configuration (sensitive data removed):
-{json.dumps({k: v for k, v in SNOWFLAKE_CONFIG.items() if k != "password"}, indent=2)}
+{json.dumps(safe_config_echo(), indent=2)}
 
 Please provide:
 1. Likely causes of the issue
@@ -541,6 +943,7 @@ Please provide:
 
     raise ValueError(f"Unknown prompt: {name}")
 
+
 @server.list_tools()
 async def handle_list_tools() -> list[types.Tool]:
     """
@@ -551,11 +954,7 @@ async def handle_list_tools() -> list[types.Tool]:
         types.Tool(
             name="get-connection-info",
             description="Get current Snowflake connection information and server status",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "additionalProperties": False
-            },
+            inputSchema={"type": "object", "properties": {}, "additionalProperties": False},
         ),
         types.Tool(
             name="add-note",
@@ -563,11 +962,15 @@ async def handle_list_tools() -> list[types.Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "name": {"type": "string", "minLength": 1, "description": "Note name/identifier"},
-                    "content": {"type": "string", "minLength": 1, "description": "Note content"}
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Note name/identifier",
+                    },
+                    "content": {"type": "string", "minLength": 1, "description": "Note content"},
                 },
                 "required": ["name", "content"],
-                "additionalProperties": False
+                "additionalProperties": False,
             },
         ),
         types.Tool(
@@ -579,7 +982,7 @@ async def handle_list_tools() -> list[types.Tool]:
                     "name": {"type": "string", "minLength": 1, "description": "Note name to delete"}
                 },
                 "required": ["name"],
-                "additionalProperties": False
+                "additionalProperties": False,
             },
         ),
         types.Tool(
@@ -592,32 +995,32 @@ async def handle_list_tools() -> list[types.Tool]:
                         "type": "string",
                         "description": "SQL query to execute",
                         "minLength": 1,
-                        "examples": ["SELECT CURRENT_TIMESTAMP()", "SHOW DATABASES"]
+                        "examples": ["SELECT CURRENT_TIMESTAMP()", "SHOW DATABASES"],
                     },
                     "format": {
                         "type": "string",
                         "enum": ["json", "markdown", "csv"],
                         "default": "json",
-                        "description": "Output format for results"
-                    }
+                        "description": "Output format for results",
+                    },
                 },
                 "required": ["sql"],
-                "additionalProperties": False
+                "additionalProperties": False,
             },
         ),
         types.Tool(
             name="list-snowflake-warehouses",
-            description="List available Data Warehouses (DWH) on Snowflake with detailed information",
+            description="List available Snowflake Data Warehouses (DWH) with details",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "include_details": {
                         "type": "boolean",
                         "default": True,
-                        "description": "Include detailed warehouse information"
+                        "description": "Include detailed warehouse information",
                     }
                 },
-                "additionalProperties": False
+                "additionalProperties": False,
             },
         ),
         types.Tool(
@@ -629,30 +1032,46 @@ async def handle_list_tools() -> list[types.Tool]:
                     "pattern": {
                         "type": "string",
                         "description": "Filter databases by name pattern (supports wildcards)",
-                        "examples": ["PROD_%", "%_DEV"]
+                        "examples": ["PROD_%", "%_DEV"],
                     },
                     "include_details": {
                         "type": "boolean",
                         "default": False,
-                        "description": "Include database details and metadata"
-                    }
+                        "description": "Include database details and metadata",
+                    },
                 },
-                "additionalProperties": False
+                "additionalProperties": False,
             },
         ),
         types.Tool(
             name="execute-query",
-            description="Execute a SQL query with read-only protection and flexible output format",
+            description=(
+                "Execute a SQL query with server-enforced read-only protection and "
+                "flexible output format. Read-only mode is governed by server "
+                "configuration and cannot be overridden by the caller."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "sql": {"type": "string", "description": "SQL query to execute", "minLength": 1},
-                    "read_only": {"type": "boolean", "default": True, "description": "Allow only read-only queries"},
-                    "format": {"type": "string", "enum": ["markdown", "json", "csv"], "default": "markdown"},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": 50000, "description": "Maximum rows to return"}
+                    "sql": {
+                        "type": "string",
+                        "description": "SQL query to execute",
+                        "minLength": 1,
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["markdown", "json", "csv"],
+                        "default": "markdown",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50000,
+                        "description": "Maximum rows to return",
+                    },
                 },
                 "required": ["sql"],
-                "additionalProperties": False
+                "additionalProperties": False,
             },
         ),
         types.Tool(
@@ -661,14 +1080,91 @@ async def handle_list_tools() -> list[types.Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "database": {"type": "string", "description": "Database to export (optional - exports all if not specified)"},
-                    "format": {"type": "string", "enum": ["json", "yaml", "sql"], "default": "json"},
-                    "include_data_samples": {"type": "boolean", "default": False, "description": "Include sample data"}
+                    "database": {
+                        "type": "string",
+                        "description": "Database to export (optional; exports all if omitted)",
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "yaml", "sql"],
+                        "default": "json",
+                    },
+                    "include_data_samples": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Include sample data",
+                    },
                 },
-                "additionalProperties": False
+                "additionalProperties": False,
             },
-        )
+        ),
     ]
+
+
+def _text(content: str) -> list[types.TextContent]:
+    """Wrap a string as the standard single-item TextContent response (CQ-H3)."""
+    return [types.TextContent(type="text", text=content)]
+
+
+def _render_output(data: Any, format_type: str) -> str:
+    """Render query result data as json (default), markdown, or csv."""
+    if format_type in ("markdown", "csv"):
+        # Non-SELECT statements return a status dict; render it as a one-row
+        # table/CSV rather than silently falling back to JSON.
+        rows = data if isinstance(data, list) else [data] if isinstance(data, dict) else None
+        if rows is not None:
+            if format_type == "markdown":
+                return _format_markdown_table(rows)
+            if not rows:
+                return "No data returned"
+            import csv
+            import io
+
+            buffer = io.StringIO()
+            writer = csv.DictWriter(buffer, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+            return buffer.getvalue()
+    return json.dumps(data, indent=2, default=str)
+
+
+def _coerce_limit(raw_limit: Any, sql: str) -> int | None:
+    """
+    Resolve the row limit, server-side, as a bounded integer (SEC-H2).
+
+    Never trusts the schema-declared type: a non-conforming client could send a
+    string or an out-of-range value. The limit is applied at the driver via
+    fetchmany, so it is never concatenated into SQL text.
+    """
+    if raw_limit is not None:
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("'limit' must be an integer") from exc
+        return max(1, min(limit, MAX_QUERY_LIMIT))
+    # Apply a default row cap to row-producing reads (SELECT and WITH ... SELECT)
+    # that do not already constrain themselves with a LIMIT. Use a tokenized check
+    # so an identifier containing the substring "LIMIT" (e.g. delimiter_col) does
+    # not suppress the cap, and so CTE-fronted reads are also bounded.
+    cleaned = _strip_sql_noise(sql)
+    first_match = _WORD_RE.match(cleaned)
+    first_word = first_match.group(0).upper() if first_match else ""
+    if first_word in ("SELECT", "WITH") and not _LIMIT_KEYWORD_RE.search(cleaned):
+        return DEFAULT_QUERY_LIMIT
+    return None
+
+
+def _run_user_query(sql: str, format_type: str, description: str, row_limit: int | None):
+    """
+    Shared execution path for the user-facing SQL tools (CQ-M1). Read-only
+    enforcement and row limiting happen inside _safe_snowflake_execute, the single
+    SQL chokepoint, so neither tool can bypass them.
+    """
+    result = _safe_snowflake_execute(sql, description, is_user_sql=True, row_limit=row_limit)
+    if result["success"]:
+        return _text(_render_output(result["data"], format_type))
+    return _text(f"Snowflake error: {result['error']}")
+
 
 @server.call_tool()
 async def handle_call_tool(
@@ -678,25 +1174,36 @@ async def handle_call_tool(
     Handle tool execution requests with comprehensive error handling and validation.
     Tools can modify server state and notify clients of changes.
     """
-    logger.info(f"Executing tool: {name} with arguments: {arguments}")
+    # Log the tool name and argument keys only; argument values may contain SQL
+    # with embedded PII/secrets, so the full payload is reserved for DEBUG (CQ-M4).
     args = arguments or {}
+    logger.info("Executing tool: %s (args: %s)", name, sorted(args.keys()))
+    logger.debug("Tool %s full arguments: %s", name, args)
+
+    # In-process rate limiting across all tools (SEC-M3).
+    if _RATE_LIMIT_ENABLED and not _rate_limiter.allow():
+        logger.warning("Rate limit exceeded; rejecting tool call: %s", name)
+        return _text("Rate limit exceeded. Please slow down and retry shortly.")
 
     try:
         # Connection and metadata tools
         if name == "get-connection-info":
-            result = _safe_snowflake_execute("SELECT CURRENT_VERSION(), CURRENT_USER(), CURRENT_DATABASE(), CURRENT_SCHEMA(), CURRENT_WAREHOUSE()", "Connection info")
+            result = _safe_snowflake_execute(
+                "SELECT CURRENT_VERSION(), CURRENT_USER(), CURRENT_DATABASE(), "
+                "CURRENT_SCHEMA(), CURRENT_WAREHOUSE()",
+                "Connection info",
+            )
             if result["success"]:
                 info = {
                     "server_info": SERVER_INFO,
                     "connection_status": "connected",
                     "snowflake_info": result["data"][0] if result["data"] else {},
-                    "config": {k: v for k, v in SNOWFLAKE_CONFIG.items() if k != "password"},
-                    "read_only_mode": MCP_READ_ONLY,
-                    "timestamp": datetime.now().isoformat()
+                    "config": safe_config_echo(),
+                    "read_only_mode": READ_ONLY,
+                    "timestamp": datetime.now().isoformat(),
                 }
-                return [types.TextContent(type="text", text=json.dumps(info, indent=2))]
-            else:
-                return [types.TextContent(type="text", text=f"Connection error: {result['error']}")]
+                return _text(json.dumps(info, indent=2))
+            return _text(f"Connection error: {result['error']}")
 
         # Note management tools
         elif name == "add-note":
@@ -704,64 +1211,60 @@ async def handle_call_tool(
             content = args.get("content")
             if not note_name or not content:
                 raise ValueError("Both 'name' and 'content' are required")
+            if len(content) > _NOTES_MAX_LENGTH:
+                raise ValueError(
+                    f"Note content exceeds maximum length of {_NOTES_MAX_LENGTH} characters"
+                )
+            # Bound the in-memory store (SEC-L2): allow updates to existing notes,
+            # but cap the number of distinct notes.
+            if note_name not in notes and len(notes) >= _NOTES_MAX_COUNT:
+                raise ValueError(
+                    f"Note limit reached ({_NOTES_MAX_COUNT}); delete a note before adding more"
+                )
 
             old_content = notes.get(note_name)
             notes[note_name] = content
-
-            return [types.TextContent(type="text", text=f"Note '{note_name}' {'updated' if old_content else 'created'} successfully")]
+            return _text(
+                f"Note '{note_name}' {'updated' if old_content else 'created'} successfully"
+            )
 
         elif name == "delete-note":
             note_name = args.get("name")
             if not note_name:
                 raise ValueError("'name' parameter is required")
-
             if note_name in notes:
                 del notes[note_name]
-                return [types.TextContent(type="text", text=f"Note '{note_name}' deleted successfully")]
-            else:
-                return [types.TextContent(type="text", text=f"Note '{note_name}' not found")]
+                return _text(f"Note '{note_name}' deleted successfully")
+            return _text(f"Note '{note_name}' not found")
 
-        # Enhanced Snowflake tools
+        # Snowflake SQL tools — both route through the same governed path.
         elif name == "execute-snowflake-sql":
             sql = args.get("sql")
-            format_type = args.get("format", "json")
             if not sql:
                 raise ValueError("'sql' parameter is required")
+            format_type = args.get("format", "json")
+            return _run_user_query(sql, format_type, "SQL execution", None)
 
-            result = _safe_snowflake_execute(sql, "SQL execution")
-            if result["success"]:
-                if format_type == "markdown" and isinstance(result["data"], list):
-                    output = _format_markdown_table(result["data"])
-                elif format_type == "csv" and isinstance(result["data"], list):
-                    if result["data"]:
-                        import csv
-                        import io
-                        output_buffer = io.StringIO()
-                        writer = csv.DictWriter(output_buffer, fieldnames=result["data"][0].keys())
-                        writer.writeheader()
-                        writer.writerows(result["data"])
-                        output = output_buffer.getvalue()
-                    else:
-                        output = "No data returned"
-                else:
-                    output = json.dumps(result["data"], indent=2, default=str)
-                return [types.TextContent(type="text", text=output)]
-            else:
-                return [types.TextContent(type="text", text=f"Snowflake error: {result['error']}")]
+        elif name == "execute-query":
+            sql = args.get("sql")
+            if not sql:
+                raise ValueError("'sql' parameter is required")
+            # NOTE: read-only is governed solely by server config; there is
+            # deliberately no client-supplied read_only argument (SEC-C2, SEC-M1).
+            format_type = args.get("format", "markdown")
+            row_limit = _coerce_limit(args.get("limit"), sql)
+            return _run_user_query(sql, format_type, "Execute query", row_limit)
 
         elif name == "list-snowflake-warehouses":
             include_details = args.get("include_details", True)
-            query = "SHOW WAREHOUSES"
-            result = _safe_snowflake_execute(query, "List warehouses")
+            result = _safe_snowflake_execute("SHOW WAREHOUSES", "List warehouses")
             if result["success"]:
                 if include_details:
                     output = json.dumps(result["data"], indent=2, default=str)
                 else:
-                    warehouses = [row.get("name", "") for row in result["data"]]
-                    output = "\n".join(warehouses)
-                return [types.TextContent(type="text", text=output)]
-            else:
-                return [types.TextContent(type="text", text=f"Snowflake error: {result['error']}")]
+                    output = "\n".join(row.get("name", "") for row in result["data"])
+                return _text(output)
+            return _text(f"Snowflake error: {result['error']}")
 
         elif name == "list-databases":
             pattern = args.get("pattern")
@@ -769,113 +1272,78 @@ async def handle_call_tool(
 
             query = "SHOW DATABASES"
             if pattern:
-                query += f" LIKE '{pattern}'"
+                # Validate before interpolation: SHOW ... LIKE takes no binds (SEC-H1).
+                query += f" LIKE '{validate_like_pattern(pattern, 'pattern')}'"
 
             result = _safe_snowflake_execute(query, "List databases")
             if result["success"]:
                 if include_details:
                     output = json.dumps(result["data"], indent=2, default=str)
                 else:
-                    databases = [row.get("name", "") for row in result["data"]]
-                    output = "\n".join(databases)
-                return [types.TextContent(type="text", text=output)]
-            else:
-                return [types.TextContent(type="text", text=f"Snowflake error: {result['error']}")]
-
-        elif name == "execute-query":
-            sql = args.get("sql")
-            if not sql:
-                raise ValueError("'sql' parameter is required")
-
-            read_only = args.get("read_only", MCP_READ_ONLY)
-            format_type = args.get("format", "markdown")
-            limit = args.get("limit")
-
-            # Check if query is allowed in read-only mode
-            allowed_commands = ["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH"]
-            first_word = sql.strip().split()[0].upper() if sql.strip() else ""
-
-            if read_only and first_word not in allowed_commands:
-                return [types.TextContent(type="text", text="Only read-only queries are allowed in read-only mode.")]
-
-            # Apply limit if specified, or use default for SELECT queries
-            if limit:
-                # Validate limit doesn't exceed maximum
-                if limit > MAX_QUERY_LIMIT:
-                    limit = MAX_QUERY_LIMIT
-                    logger.warning(f"Query limit reduced from {args.get('limit')} to maximum {MAX_QUERY_LIMIT}")
-            elif first_word == "SELECT" and "LIMIT" not in sql.upper():
-                # Apply default limit for SELECT queries without explicit limit
-                limit = DEFAULT_QUERY_LIMIT
-                logger.info(f"Applying default limit {DEFAULT_QUERY_LIMIT} to SELECT query")
-
-            if limit and "LIMIT" not in sql.upper():
-                sql += f" LIMIT {limit}"
-
-            result = _safe_snowflake_execute(sql, "Execute query")
-            if result["success"]:
-                if format_type == "markdown":
-                    output = _format_markdown_table(result["data"])
-                else:
-                    output = json.dumps(result["data"], indent=2, default=str)
-                return [types.TextContent(type="text", text=output)]
-            else:
-                return [types.TextContent(type="text", text=f"Snowflake error: {result['error']}")]
+                    output = "\n".join(row.get("name", "") for row in result["data"])
+                return _text(output)
+            return _text(f"Snowflake error: {result['error']}")
 
         elif name == "export-schema":
             database = args.get("database")
             format_type = args.get("format", "json")
-            include_samples = args.get("include_data_samples", False)
 
-            schema_data = {"exported_at": datetime.now().isoformat(), "server_info": SERVER_INFO}
+            schema_data = {
+                "exported_at": datetime.now().isoformat(),
+                "server_info": SERVER_INFO,
+            }
 
-            # Get database information
             if database:
-                db_query = f"SHOW DATABASES LIKE '{database}'"
+                db_query = f"SHOW DATABASES LIKE '{validate_like_pattern(database, 'database')}'"
             else:
                 db_query = "SHOW DATABASES"
 
             db_result = _safe_snowflake_execute(db_query, "Export schema - databases")
             if not db_result["success"]:
-                return [types.TextContent(type="text", text=f"Error getting database info: {db_result['error']}")]
+                return _text(f"Error getting database info: {db_result['error']}")
 
             schema_data["databases"] = db_result["data"]
 
-            if format_type == "json":
-                output = json.dumps(schema_data, indent=2, default=str)
-            elif format_type == "yaml":
-                try:
-                    import yaml
-                    output = yaml.dump(schema_data, default_flow_style=False)
-                except ImportError:
-                    output = json.dumps(schema_data, indent=2, default=str) + "\n\n# Note: YAML format requires PyYAML package"
-            else:  # SQL format
+            if format_type == "yaml":
+                output = yaml.dump(schema_data, default_flow_style=False)
+            elif format_type == "sql":
                 output = f"-- Schema export generated at {schema_data['exported_at']}\n"
                 output += f"-- Server: {SERVER_INFO['name']} v{SERVER_INFO['version']}\n\n"
                 for db in schema_data["databases"]:
                     output += f"-- Database: {db.get('name', 'Unknown')}\n"
+            else:  # json
+                output = json.dumps(schema_data, indent=2, default=str)
 
-            return [types.TextContent(type="text", text=output)]
+            return _text(output)
 
         else:
             raise ValueError(f"Unknown tool: {name}")
 
+    except ValueError as e:
+        # Our own validation messages are safe to surface verbatim.
+        logger.info("Tool %s rejected input: %s", name, e)
+        return _text(f"Invalid request: {e}")
     except Exception as e:
-        logger.error(f"Tool execution failed: {name} - {str(e)}")
-        return [types.TextContent(type="text", text=f"Tool execution error: {str(e)}")]
+        ref = _log_exception(f"Tool execution ({name})", e)
+        return _text(f"Tool execution error (ref {ref}). See server logs for details.")
+
 
 async def test_snowflake_connection():
     """Test Snowflake connection for debugging purposes."""
     result = _safe_snowflake_execute("SELECT CURRENT_TIMESTAMP()", "Connection test")
     if result["success"]:
-        logger.info(f"Snowflake connection OK, CURRENT_TIMESTAMP: {result['data'][0] if result['data'] else 'No data'}")
+        timestamp = result["data"][0] if result["data"] else "No data"
+        logger.info("Snowflake connection OK, CURRENT_TIMESTAMP: %s", timestamp)
     else:
         logger.error(f"Snowflake connection error: {result['error']}")
+
 
 async def main():
     """Main entry point for the MCP server."""
     logger.info(f"Starting {SERVER_INFO['name']} v{SERVER_INFO['version']}")
-    logger.info(f"Configuration: Read-only mode: {MCP_READ_ONLY}, Log level: {CONFIG['logging']['level']}")
+    logger.info(
+        f"Configuration: Read-only mode: {READ_ONLY}, Log level: {CONFIG['logging']['level']}"
+    )
 
     # Test connection on startup if configured
     if CONFIG["server"]["connection"]["test_on_startup"]:
@@ -899,8 +1367,8 @@ async def main():
             read_stream,
             write_stream,
             InitializationOptions(
-                server_name=SERVER_INFO['name'],
-                server_version=SERVER_INFO['version'],
+                server_name=SERVER_INFO["name"],
+                server_version=SERVER_INFO["version"],
                 capabilities=server.get_capabilities(
                     notification_options=NotificationOptions(
                         resources_changed=notifications.get("resources_changed", True),
@@ -912,6 +1380,8 @@ async def main():
             ),
         )
 
+
 if __name__ == "__main__":
     import asyncio
+
     asyncio.run(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+"""Shared test fixtures.
+
+All tests mock ``snowflake.connector.connect``; no live Snowflake account is
+contacted. The connection-mock contract lives here so both suites stay in sync.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from simple_snowflake_mcp import server
+
+
+def build_connection(columns=None, rows=None, rowcount=0):
+    """Build a MagicMock Snowflake connection returning the given result set."""
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.description = [(c,) for c in columns] if columns else None
+    cur.fetchall.return_value = list(rows or [])
+    cur.fetchmany.return_value = list(rows or [])
+    cur.rowcount = rowcount
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cur
+    cursor_cm.__exit__.return_value = False
+    conn.cursor.return_value = cursor_cm
+    return conn
+
+
+@pytest.fixture
+def make_connection():
+    """Factory fixture returning :func:`build_connection`."""
+    return build_connection
+
+
+@pytest.fixture
+def patch_connect(monkeypatch):
+    """Return a helper that patches the connector to yield the given connection."""
+
+    def _patch(conn):
+        monkeypatch.setattr(server.snowflake.connector, "connect", lambda **kw: conn)
+
+    return _patch
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state(monkeypatch):
+    """Isolate global server state and provide dummy credentials per test."""
+    server._connection = None
+    monkeypatch.setattr(server, "_RATE_LIMIT_ENABLED", False)
+    monkeypatch.setattr(server, "READ_ONLY", True)
+    server.notes.clear()
+    monkeypatch.setenv("SNOWFLAKE_USER", "u")
+    monkeypatch.setenv("SNOWFLAKE_PASSWORD", "p")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "a")
+    yield
+    server._connection = None
+    server.notes.clear()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,282 @@
+"""Security regression tests for the remediation of the audit findings.
+
+Each test references the audit finding it guards against. The Snowflake connector
+is mocked throughout; no live account is contacted.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from simple_snowflake_mcp import server
+
+
+# ---------------------------------------------------------------------------
+# Read-only keyword guard (SEC-C1, SEC-C2, CQ-H1)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1",
+        "  select * from t",
+        "SHOW DATABASES",
+        "DESCRIBE TABLE t",
+        "EXPLAIN SELECT 1",
+        "WITH x AS (SELECT 1) SELECT * FROM x",
+        "/* comment */ SELECT 1",
+        "-- lead comment\nSELECT 1",
+    ],
+)
+def test_read_only_accepts_reads(sql):
+    assert server.is_read_only_sql(sql) is True
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "DELETE FROM t",
+        "DROP TABLE t",
+        "UPDATE t SET a = 1",
+        "INSERT INTO t VALUES (1)",
+        "GRANT ROLE ACCOUNTADMIN TO USER x",
+        "CREATE TABLE t (a int)",
+        "TRUNCATE TABLE t",
+        # CTE-fronted DML must be rejected even though it starts with WITH.
+        "WITH x AS (SELECT 1) DELETE FROM t WHERE id IN (SELECT id FROM x)",
+        # Multi-statement input must be rejected.
+        "SELECT 1; DROP TABLE t",
+        # Comment cannot smuggle a write past the first-keyword check.
+        "/* SELECT */ DELETE FROM t",
+        "",
+        "   ",
+    ],
+)
+def test_read_only_rejects_writes(sql):
+    assert server.is_read_only_sql(sql) is False
+
+
+# ---------------------------------------------------------------------------
+# Identifier validation for LIKE clauses (SEC-H1, CQ-C2)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("value", ["PROD_DB", "PROD_%", "abc123", "%_DEV"])
+def test_valid_like_patterns(value):
+    assert server.validate_like_pattern(value, "pattern") == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["'; DROP TABLE t --", "a' OR '1'='1", "a b", "a;b", "a'b", "../x", "a|b"],
+)
+def test_invalid_like_patterns_raise(value):
+    with pytest.raises(ValueError):
+        server.validate_like_pattern(value, "pattern")
+
+
+# ---------------------------------------------------------------------------
+# Limit coercion (SEC-H2)
+# ---------------------------------------------------------------------------
+def test_limit_clamped_to_max(monkeypatch):
+    monkeypatch.setattr(server, "MAX_QUERY_LIMIT", 50)
+    assert server._coerce_limit(10_000, "SELECT 1") == 50
+
+
+def test_limit_string_is_coerced(monkeypatch):
+    monkeypatch.setattr(server, "MAX_QUERY_LIMIT", 50000)
+    assert server._coerce_limit("25", "SELECT 1") == 25
+
+
+def test_limit_invalid_raises():
+    with pytest.raises(ValueError):
+        server._coerce_limit("1 UNION SELECT password", "SELECT 1")
+
+
+def test_default_limit_applied_to_bare_select(monkeypatch):
+    monkeypatch.setattr(server, "DEFAULT_QUERY_LIMIT", 1000)
+    assert server._coerce_limit(None, "SELECT * FROM t") == 1000
+    # A query that already constrains itself is left alone.
+    assert server._coerce_limit(None, "SELECT * FROM t LIMIT 5") is None
+    assert server._coerce_limit(None, "SHOW DATABASES") is None
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering safety (CQ-L2)
+# ---------------------------------------------------------------------------
+def test_markdown_escapes_pipes_and_nulls():
+    table = server._format_markdown_table([{"a": "x|y", "b": None}])
+    lines = table.splitlines()
+    assert "x\\|y" in lines[2]
+    # None renders as an empty cell, not the string "None".
+    assert "None" not in table
+
+
+# ---------------------------------------------------------------------------
+# Lazy config loading (CQ-C3)
+# ---------------------------------------------------------------------------
+def test_get_snowflake_config_requires_credentials(monkeypatch):
+    monkeypatch.delenv("SNOWFLAKE_USER", raising=False)
+    monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+    with pytest.raises(server.SnowflakeConfigError):
+        server.get_snowflake_config()
+
+
+def test_get_snowflake_config_reads_env_lazily(monkeypatch):
+    monkeypatch.setenv("SNOWFLAKE_USER", "alice")
+    monkeypatch.setenv("SNOWFLAKE_PASSWORD", "secret")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct")
+    cfg = server.get_snowflake_config()
+    assert cfg["user"] == "alice"
+    # Statement timeout is applied as a session parameter.
+    assert "STATEMENT_TIMEOUT_IN_SECONDS" in cfg["session_parameters"]
+
+
+def test_safe_config_echo_excludes_password(monkeypatch):
+    monkeypatch.setenv("SNOWFLAKE_USER", "alice")
+    monkeypatch.setenv("SNOWFLAKE_PASSWORD", "secret")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct")
+    echo = server.safe_config_echo()
+    assert "password" not in echo
+    assert "secret" not in echo.values()
+
+
+# ---------------------------------------------------------------------------
+# Config validation & path traversal (SEC-M4)
+# ---------------------------------------------------------------------------
+def test_config_path_traversal_is_blocked(monkeypatch):
+    monkeypatch.setenv("CONFIG_FILE", "../../../../etc/passwd")
+    resolved = server._resolve_config_path()
+    assert resolved.is_relative_to(server.REPO_ROOT)
+    assert resolved.name == "config.yaml"
+
+
+def test_validate_config_coerces_types():
+    cfg = server._validate_config({"snowflake": {"read_only": "false", "max_query_limit": "abc"}})
+    # A string "false" must become a real bool, not stay truthy.
+    assert cfg["snowflake"]["read_only"] is False
+    # A non-integer limit falls back to the validated default.
+    assert isinstance(cfg["snowflake"]["max_query_limit"], int)
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter (SEC-M3)
+# ---------------------------------------------------------------------------
+def test_rate_limiter_blocks_after_max():
+    limiter = server._RateLimiter(max_calls=2, window_seconds=60)
+    assert limiter.allow() is True
+    assert limiter.allow() is True
+    assert limiter.allow() is False
+
+
+# ---------------------------------------------------------------------------
+# Read-only guard must NOT false-reject legitimate reads (regression)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Semicolon inside a string literal (e.g. LISTAGG separator).
+        "SELECT LISTAGG(name, ';') FROM t",
+        "SELECT * FROM t WHERE x = 'a;b'",
+        # Write-token words used as functions inside a CTE.
+        "WITH c AS (SELECT REPLACE(a, 'x', 'y') AS r FROM t) SELECT * FROM c",
+        "WITH c AS (SELECT GET(v, 'k') AS g FROM t) SELECT * FROM c",
+        # Keyword-like word inside a quoted identifier.
+        'WITH c AS (SELECT 1 AS "DELETE") SELECT * FROM c',
+    ],
+)
+def test_read_only_does_not_false_reject(sql):
+    assert server.is_read_only_sql(sql) is True
+
+
+# ---------------------------------------------------------------------------
+# Default row cap must cover CTE reads and tolerate "LIMIT"-substring names
+# ---------------------------------------------------------------------------
+def test_default_limit_covers_cte_reads(monkeypatch):
+    monkeypatch.setattr(server, "DEFAULT_QUERY_LIMIT", 1000)
+    assert server._coerce_limit(None, "WITH x AS (SELECT * FROM t) SELECT * FROM x") == 1000
+
+
+def test_default_limit_not_suppressed_by_limit_substring(monkeypatch):
+    monkeypatch.setattr(server, "DEFAULT_QUERY_LIMIT", 1000)
+    # "delimiter_col" contains the substring LIMIT but no LIMIT clause.
+    assert server._coerce_limit(None, "SELECT delimiter_col FROM t") == 1000
+
+
+def test_valid_dollar_identifier_pattern():
+    assert server.validate_like_pattern("SALES$2024", "database") == "SALES$2024"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end enforcement through the tool dispatch
+# ---------------------------------------------------------------------------
+async def test_execute_snowflake_sql_enforces_read_only(monkeypatch):
+    """SEC-C1: the previously-unguarded tool must now reject writes."""
+    connect = MagicMock(side_effect=AssertionError("must not connect for a rejected write"))
+    monkeypatch.setattr(server.snowflake.connector, "connect", connect)
+
+    result = await server.handle_call_tool(
+        "execute-snowflake-sql", {"sql": "DROP TABLE PROD.PUBLIC.CUSTOMERS"}
+    )
+
+    assert "read-only" in result[0].text.lower()
+    connect.assert_not_called()
+
+
+async def test_execute_query_ignores_client_read_only_flag(monkeypatch):
+    """SEC-C2/SEC-M1: a client-supplied read_only:false must not relax the policy."""
+    connect = MagicMock(side_effect=AssertionError("must not connect"))
+    monkeypatch.setattr(server.snowflake.connector, "connect", connect)
+
+    result = await server.handle_call_tool(
+        "execute-query", {"sql": "DELETE FROM t", "read_only": False}
+    )
+
+    assert "read-only" in result[0].text.lower()
+    connect.assert_not_called()
+
+
+async def test_cte_fronted_dml_rejected(monkeypatch):
+    connect = MagicMock(side_effect=AssertionError("must not connect"))
+    monkeypatch.setattr(server.snowflake.connector, "connect", connect)
+
+    result = await server.handle_call_tool(
+        "execute-query",
+        {"sql": "WITH x AS (SELECT 1) DELETE FROM prod.public.orders"},
+    )
+
+    assert "read-only" in result[0].text.lower()
+
+
+async def test_sql_injection_pattern_rejected(make_connection, patch_connect):
+    patch_connect(make_connection())
+    result = await server.handle_call_tool("list-databases", {"pattern": "x'; DROP TABLE t --"})
+    assert "Invalid request" in result[0].text
+
+
+async def test_db_error_is_not_leaked_to_client(monkeypatch):
+    """SEC-H3: raw Snowflake error text must not reach the client."""
+    secret = "account=topsecret123 table=PROD.SSN"
+    monkeypatch.setattr(
+        server.snowflake.connector,
+        "connect",
+        MagicMock(side_effect=Exception(secret)),
+    )
+
+    result = await server.handle_call_tool("execute-query", {"sql": "SELECT 1"})
+
+    text = result[0].text
+    assert "topsecret123" not in text
+    assert "ref" in text.lower()
+
+
+async def test_note_count_is_capped(monkeypatch):
+    """SEC-L2: the in-memory notes store must be bounded."""
+    monkeypatch.setattr(server, "_NOTES_MAX_COUNT", 2)
+    monkeypatch.setattr(server, "_NOTES_MAX_LENGTH", 10000)
+    server.notes.clear()
+
+    await server.handle_call_tool("add-note", {"name": "a", "content": "1"})
+    await server.handle_call_tool("add-note", {"name": "b", "content": "1"})
+    result = await server.handle_call_tool("add-note", {"name": "c", "content": "1"})
+
+    assert "limit reached" in result[0].text.lower()
+    server.notes.clear()

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -1,12 +1,36 @@
-import pytest
+"""Tool-dispatch smoke tests using a mocked Snowflake connection.
+
+Shared fixtures (make_connection, patch_connect, reset_server_state) live in
+conftest.py. Security-focused unit tests live in test_security.py.
+"""
 
 from simple_snowflake_mcp import server
 
 
-@pytest.mark.asyncio
-async def test_list_snowflake_warehouses():
-    # On suppose que la connexion Snowflake est valide et que le .env est bien configuré
-    result = await server.handle_call_tool("list-snowflake-warehouses", {})
-    assert isinstance(result, list)
-    assert len(result) > 0 or result[0].text.startswith("Erreur Snowflake")
-    print("Résultat:", result[0].text)
+async def test_execute_query_returns_markdown(make_connection, patch_connect):
+    patch_connect(make_connection(columns=["N"], rows=[("1",)]))
+
+    result = await server.handle_call_tool("execute-query", {"sql": "SELECT 1 AS N"})
+
+    assert result[0].text.startswith("| N |")
+
+
+async def test_list_databases_names_only(make_connection, patch_connect):
+    patch_connect(make_connection(columns=["name"], rows=[("DB1",), ("DB2",)]))
+
+    result = await server.handle_call_tool("list-databases", {})
+
+    assert "DB1" in result[0].text and "DB2" in result[0].text
+
+
+async def test_unknown_tool_is_rejected(make_connection, patch_connect):
+    patch_connect(make_connection())
+    result = await server.handle_call_tool("does-not-exist", {})
+    assert "Invalid request" in result[0].text
+
+
+async def test_add_and_delete_note():
+    created = await server.handle_call_tool("add-note", {"name": "n", "content": "c"})
+    assert "created" in created[0].text
+    deleted = await server.handle_call_tool("delete-note", {"name": "n"})
+    assert "deleted" in deleted[0].text


### PR DESCRIPTION
Harden Snowflake MCP server per security audit

Remediates the findings in security-audit-report.pdf (NOT FIT FOR PRODUCTION verdict) across all severity levels.

Read-only enforcement (SEC-C1, SEC-C2, SEC-M1, CQ-H1, CQ-M1):
- Centralize the read-only guard inside _safe_snowflake_execute so no SQL tool can skip it; both execute tools route through _run_user_query.
- Remove the client-supplied read_only argument; READ_ONLY is now governed solely by server config / MCP_READ_ONLY.
- is_read_only_sql strips comments and quoted spans, rejects multi-statement input and CTE-fronted DML, and distinguishes write keywords from same-named SQL functions.

Resource safety & lazy config (CQ-C1, CQ-C3):
- Use context managers for connections/cursors; reuse one connection.
- Load Snowflake credentials lazily at connect time, not at import.

Injection & error hardening (SEC-H1, SEC-H2, SEC-H3, CQ-C2, CQ-M2):
- validate_like_pattern allow-lists LIKE values; _coerce_limit bounds the limit and applies it via fetchmany (never concatenated).
- Return generic errors with a server-side log reference id.

Operational hardening (SEC-M2, SEC-M3, SEC-M4, CQ-H2, CQ-M4):
- Statement timeout, in-process rate limit, hashed SQL logging at INFO, CONFIG_FILE path constrained to repo + typed/bounds config validation.

Housekeeping (SEC-L1-L3, CQ-H3/H4, CQ-L2, CQ-M5/M6):
- Fix Dockerfile.secure build; read-only dev source mount; cap notes; escape markdown table cells; mocked test suite (tests/test_security.py) with one regression per finding; CI workflow runs ruff + pytest.
- README tool list and security model corrected; CLAUDE.md added.


@